### PR TITLE
Edit top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ zgoubi
 Building in Docker
 ------------------
 
-To downloand and build zgoubi and execute the tests on a system with
+To download and build zgoubi and execute the tests on a system with
 Docker installed and the Docker service running, execute the following
-in a command-line shell sucha as bash: ```bash git clone
+in a command-line shell such as bash: ```bash git clone
 https://github.com/radiasoft/zgoubi cd zgoubi ./travis.sh ``` This
 will use [cmake] to build the master branch of the zgoubi repository.
 Then it will use the companion package `ctest` to run the zgoubi test
@@ -33,15 +33,15 @@ Examples
 These examples are maintained. Efforts are made to ensure that they
 are run-able with the latest version of zgoubi executable on the
 author's `master` branch. In particular some are part of the
-tools/compare procdure which tests their repeatability.
+tools/compare procedure which tests their repeat-ability.
 
 
-The example sub-folders found in exemple have the similar following
+The example sub-folders found in example have the similar following
 content :
 
 - one or more zgoubi input data files for a given example (a file with
   suffix `.dat`), and the corresponding result files (*.res suffix),
-  and sometimes in addition *.eps plot files or other forms of
+  and sometimes in addition `*.eps` plot files or other forms of
   computation outputs,
 - or just one or more result files (suffix `.res`)
 
@@ -55,12 +55,12 @@ accepts the command `zgoubi -inFile thisExampleDataFile.dat/.res`.
 Some of these examples are discussed in Part C of the [users' guide].
 
 
-The folder exemples/tools is dedicated to the following :
+The folder examples/tools is dedicated to the following :
 
 - running `compare` will run some of the examples, and compare their
 outcomes (logged in compare.out) with reference ones logged in
 compare.out_reference.  Absence of (major) differences between
-compare.out_reference and compare.out is a sign of a good installtion
+compare.out_reference and compare.out is a sign of a good installation
 of zgoubi.
 
 [CMake]: https://www.cmake.org

--- a/README.md
+++ b/README.md
@@ -7,19 +7,21 @@ zgoubi
 
 Building in Docker
 ------------------
-To downloand and build zgoubi and execute the tests on a system with Docker installed and the Docker service 
-running, execute the following in a command-line shell sucha as bash:
-```bash
-git clone https://github.com/radiasoft/zgoubi
-cd zgoubi
-./travis.sh
-```
-This will use [cmake] to build the master branch of the zgoubi repository.  Then it will use the companion
-package `ctest` to run the zgoubi test suite.  Please submit an [issue] describing any problems you encounter.
+
+To downloand and build zgoubi and execute the tests on a system with
+Docker installed and the Docker service running, execute the following
+in a command-line shell sucha as bash: ```bash git clone
+https://github.com/radiasoft/zgoubi cd zgoubi ./travis.sh ``` This
+will use [cmake] to build the master branch of the zgoubi repository.
+Then it will use the companion package `ctest` to run the zgoubi test
+suite.  Please submit an [issue] describing any problems you
+encounter.
 
 Launching an Interactive Docker Session
 ---------------------------------------
-For an interactive, command-line interface to the docker image, execute the following docker command:
+
+For an interactive, command-line interface to the docker image,
+execute the following docker command:
 
 ```bash
 docker run -it --rm -u vagrant -v "$PWD":/home/vagrant/src/radiasoft/zgoubi "${1:-radiasoft/beamsim-part1}" bash
@@ -27,26 +29,40 @@ docker run -it --rm -u vagrant -v "$PWD":/home/vagrant/src/radiasoft/zgoubi "${1
 
 Examples
 --------
-These examples are maintained. Efforts are made to ensure that they are run-able with the latest version of zgoubi executable on the author's "trunk" branch. In particular some are part of the tools/compare procdure which tests their repeatability.
+
+These examples are maintained. Efforts are made to ensure that they
+are run-able with the latest version of zgoubi executable on the
+author's `master` branch. In particular some are part of the
+tools/compare procdure which tests their repeatability.
 
 
-The example sub-folders found in exemple have the similar following content : 
+The example sub-folders found in exemple have the similar following
+content :
 
-- one or more zgoubi input data files for a given example (a file with suffix ".dat"), and the corresponding result files (*.res suffix), and sometimes in addition *.eps plot files or other forms of computation outputs, 
+- one or more zgoubi input data files for a given example (a file with
+  suffix `.dat`), and the corresponding result files (*.res suffix),
+  and sometimes in addition *.eps plot files or other forms of
+  computation outputs,
+- or just one or more result files (suffix `.res`)
 
-- or just one or more result files (suffix ".res")
+Zgoubi needs a zgoubi.dat as input file. That zgoubi.dat is obtained
+by copy-pasting `thisExampleDataFile.dat` or `thisExampleDataFile.res`
+file in that folder, to zgoubi.dat. (that works with a .res file since
+the first part of a `.res` zgoubi result file is a copy of the
+zgoubi.dat file that it stems from).  Note that Zgoubi, instead, also
+accepts the command `zgoubi -inFile thisExampleDataFile.dat/.res`.
 
-Zgoubi needs a zgoubi.dat as input file. That zgoubi.dat is obtained by copy-pasting 'thisExampleDataFile.dat' or 'thisExampleDataFile.res' file in that folder, to zgoubi.dat. (that works with a .res file since the first part of a '.res' zgoubi result file is a copy of the zgoubi.dat file that it stems from).  
-Note that Zgoubi, instead, also accepts the command 'zgoubi -inFile thisExampleDataFile.dat/.res. 
-
-Some of these examples are discussed in Part C of the [users' guide]. 
+Some of these examples are discussed in Part C of the [users' guide].
 
 
-The folder exemples/tools is dedicated to the following : 
+The folder exemples/tools is dedicated to the following :
 
-- running 'compare' will run some of the examples, and compare their outcomes (logged in compare.out) with reference ones logged in compare.out_reference. 
-Absence of (major) differences between compare.out_reference and compare.out is a sign of a good installtion of zgoubi. 
+- running `compare` will run some of the examples, and compare their
+outcomes (logged in compare.out) with reference ones logged in
+compare.out_reference.  Absence of (major) differences between
+compare.out_reference and compare.out is a sign of a good installtion
+of zgoubi.
 
 [CMake]: https://www.cmake.org
-[issue]: https://github.com/radiasoft/zgoubi/issues
+[issue]: https://github.com/radiasoft/zgoubi/issues/new
 [users' guide]: https://www.bnl.gov/isd/documents/79375.pdf

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ Building in Docker
 
 To download and build zgoubi and execute the tests on a system with
 Docker installed and the Docker service running, execute the following
-in a command-line shell such as bash: ```bash git clone
-https://github.com/radiasoft/zgoubi cd zgoubi ./travis.sh ``` This
-will use [cmake] to build the master branch of the zgoubi repository.
+in a command-line shell such as bash:
+```bash
+git clone https://github.com/radiasoft/zgoubi
+cd zgoubi
+./travis.sh
+```
+This will use [cmake] to build the master branch of the zgoubi repository.
 Then it will use the companion package `ctest` to run the zgoubi test
 suite.  Please submit an [issue] describing any problems you
 encounter.
@@ -31,13 +35,12 @@ Examples
 --------
 
 These examples are maintained. Efforts are made to ensure that they
-are run-able with the latest version of zgoubi executable on the
-author's `master` branch. In particular some are part of the
-tools/compare procedure which tests their repeat-ability.
+are executable with the latest version of zgoubi on the
+author's `master` branch. In particular, some are part of the
+tools/compare procedure which tests their repeatability.
 
-
-The example sub-folders found in example have the similar following
-content :
+The example sub-folders found in `exemple` have the similar following
+content:
 
 - one or more zgoubi input data files for a given example (a file with
   suffix `.dat`), and the corresponding result files (*.res suffix),
@@ -54,8 +57,7 @@ accepts the command `zgoubi -inFile thisExampleDataFile.dat/.res`.
 
 Some of these examples are discussed in Part C of the [users' guide].
 
-
-The folder examples/tools is dedicated to the following :
+The folder `exemples/tools` is dedicated to the following:
 
 - running `compare` will run some of the examples, and compare their
 outcomes (logged in compare.out) with reference ones logged in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,32 @@
+[This document is formatted with GitHub-Flavored Markdown. ]:#
+[For better viewing, including hyperlinks, read it online at ]:#
+[https://github.com/radiasoft/zgoubi/blob/master/README.md ]:#
 
+zgoubi
+======
 
+Building in Docker
+------------------
+To downloand and build zgoubi and execute the tests on a system with Docker installed and the Docker service 
+running, execute the following in a command-line shell sucha as bash:
+```bash
+git clone https://github.com/radiasoft/zgoubi
+cd zgoubi
+./travis.sh
+```
+This will use [cmake] to build the master branch of the zgoubi repository.  Then it will use the companion
+package `ctest` to run the zgoubi test suite.  Please submit an [issue] describing any problems you encounter.
+
+Launching an Interactive Docker Session
+---------------------------------------
+For an interactive, command-line interface to the docker image, execute the following docker command:
+
+```bash
+docker run -it --rm -u vagrant -v "$PWD":/home/vagrant/src/radiasoft/zgoubi "${1:-radiasoft/beamsim-part1}" bash
+```
+
+Examples
+--------
 These examples are maintained. Efforts are made to ensure that they are run-able with the latest version of zgoubi executable on the author's "trunk" branch. In particular some are part of the tools/compare procdure which tests their repeatability.
 
 
@@ -12,7 +39,7 @@ The example sub-folders found in exemple have the similar following content :
 Zgoubi needs a zgoubi.dat as input file. That zgoubi.dat is obtained by copy-pasting 'thisExampleDataFile.dat' or 'thisExampleDataFile.res' file in that folder, to zgoubi.dat. (that works with a .res file since the first part of a '.res' zgoubi result file is a copy of the zgoubi.dat file that it stems from).  
 Note that Zgoubi, instead, also accepts the command 'zgoubi -inFile thisExampleDataFile.dat/.res. 
 
-Some of these examples are discussed in Part C of the users' guide. 
+Some of these examples are discussed in Part C of the [users' guide]. 
 
 
 The folder exemples/tools is dedicated to the following : 
@@ -20,3 +47,6 @@ The folder exemples/tools is dedicated to the following :
 - running 'compare' will run some of the examples, and compare their outcomes (logged in compare.out) with reference ones logged in compare.out_reference. 
 Absence of (major) differences between compare.out_reference and compare.out is a sign of a good installtion of zgoubi. 
 
+[CMake]: https://www.cmake.org
+[issue]: https://github.com/radiasoft/zgoubi/issues
+[users' guide]: https://www.bnl.gov/isd/documents/79375.pdf


### PR DESCRIPTION
1. Rename README as README.md to exploit GitHub-flavored Markdown.
2. Format with Markdown, including inserting hyperlinks.
3. Add zgoubi build instructions and docker image launch instructions.