### PR TITLE
fix #48 comment out failing lines in kstop.f which had also been comm…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 env:
   global:
-    - DOCKER_IMG="radiasoft/beamsim-part1"
+    - DOCKER_IMG="radiasoft/beamsim"
     - BUILD_DIR="cmake-build"
 
 before_install:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ make install
 The [travis.sh](./travis.sh) script shows an analogous process we use
 to build and test zgoubi on
 [Travis-CI.org](https://travis-ci.org/radiasoft/zgoubi/branches) via
-the radiasoft/beamsim-part1 docker image.
+the radiasoft/beamsim docker image.
 
 Building with make
 ------------------
@@ -43,5 +43,3 @@ guide.
 `Makefile_zgoubi_ifort` will build zgoubi and zgoubi users' guide, it
 will not build `zpop`. The latter will require `make -f
 Makefile_zpop_ifort`.
-
-

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For an interactive, command-line interface to the docker image,
 execute the following docker command:
 
 ```bash
-docker run -it --rm -u vagrant -v "$PWD":/home/vagrant/src/radiasoft/zgoubi "${1:-radiasoft/beamsim-part1}" bash
+docker run -it --rm -u vagrant -v "$PWD":/home/vagrant/src/radiasoft/zgoubi "${1:-radiasoft/beamsim}" bash
 ```
 
 Examples

--- a/travis.sh
+++ b/travis.sh
@@ -7,7 +7,7 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
-docker run -i --rm -u vagrant -v "$PWD":/home/vagrant/src/radiasoft/zgoubi "${1:-radiasoft/beamsim-part1}" bash <<-'EOF'
+docker run -i --rm -u vagrant -v "$PWD":/home/vagrant/src/radiasoft/zgoubi "${1:-radiasoft/beamsim}" bash <<-'EOF'
     #!/bin/bash
     source ~/.bashrc
     set -veuo pipefail

--- a/zgoubi/endjob.f
+++ b/zgoubi/endjob.f
@@ -52,10 +52,10 @@ C          WRITE(LUN,FMT='(/,''End of job !'',//,''  '')')
         ENDIF
       ENDIF
       WRITE(6,201)
-      WRITE(NRES,*) ' '
-      WRITE(NRES,201)
-      WRITE(NRES,201)
-      WRITE(NRES,201)
+      WRITE(LUN,*) ' '
+      WRITE(LUN,201)
+      WRITE(LUN,201)
+      WRITE(LUN,201)
  201  FORMAT(132('*'))
       STOP
       END

--- a/zgoubi/kstop.f
+++ b/zgoubi/kstop.f
@@ -126,17 +126,22 @@ C     $     IREP(MXT),AMQLU,PABSLU
      >  ') : '//TXT(DEBSTR(TXT):FINSTR(TXT))//' ;  remain/launched= ',
      >    IMX-NSTOP,'/',IMX
 
-        INQUIRE(UNIT=NFAI,ERR=99,IOSTAT=IOS,OPENED=OPN)
-        IF(OPN) THEN
-C          CALL ZGNOEL(
-C     >               NOEL)         
-          CALL ZGKLEY(  
-     >                KEY)
-          CALL ZGKLEY(  
-     >                LBL1,LBL2)
-          KPR = 1 
-          CALL IMPFAI(KPR,NOEL,KLEY,LBL1,LBL2) 
-        ENDIF
+C Goal here is to have particle data logged to zgoubi.fai when it is stopped.
+C However, commented as impfai seems to cause fishy outputs to zgoubi.fai. Could be because
+C some particle data not clean when going to kstop.
+C To be debugged (launch some particles that get lost in an element, while zgoubi.fai has
+C been opened beforehanf by FAISTORE).
+C        INQUIRE(UNIT=NFAI,ERR=99,IOSTAT=IOS,OPENED=OPN)
+C        OPN = OPN .AND. NFAI .GT. 0
+C        IF(OPN) THEN
+C          CALL ZGKLEY(
+C     >                KEY)
+C          CALL ZGKLEY(
+C     >                LBL1,LBL2)
+C          KPR = 1
+C          CALL IMPFAI(KPR,NOEL,KLEY,LBL1,LBL2)
+C        ENDIF
+
         CALL FLUSH2(ABS(NRES),.FALSE.) 
       ENDIF 
 


### PR DESCRIPTION
…ented out in the zgoubi SVN codebase. Renamed variable in endjob.f from NRES to LUN as it appears in the SVN codebase to fix a segfault when all particles are lost.

This change, or something similar is needed before zgoubi can be released to sirepo servers to prevent the disk from filling up in error cases.